### PR TITLE
Fixed min version for Module::Install::TestML.

### DIFF
--- a/lib/Module/Package/Ingy.pm
+++ b/lib/Module/Package/Ingy.pm
@@ -38,7 +38,7 @@ use Module::Install::ReadmeFromPod 0.12 ();
 use Module::Install::RequiresList 0.10 ();
 use Module::Install::Stardoc 0.18 ();
 use Module::Install::TestCommon 0.07 ();
-use Module::Install::TestML 0.26 ();
+use Module::Install::TestML 0.02 ();
 use Module::Install::VersionCheck 0.16 ();
 my $testbase_skip = "
 use Module::Install::TestBase 0;


### PR DESCRIPTION
Hi @ingydotnet 

Please review the PR.
I received Module::Package distribution as part of PRC2018 for the month of June 2018. In order to install the distribution, I had to get the dependent distribution fix. 
This PR resolved that issue.

Many Thanks.
Best Regards,
Mohammad S Anwar